### PR TITLE
systemd unit: run as 'daemon' user, not root

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+0.4.
+-----
+
+- systemd unit: run as 'daemon' user, not root;
+  packagers should make sure to chown /var/spool/uptimed/
+  on update
+
 0.4.0
 -----
 

--- a/etc/uptimed.service.in
+++ b/etc/uptimed.service.in
@@ -6,6 +6,7 @@ Documentation=man:uptimed(8) man:uprecords(1)
 Type=notify
 ExecStart=@prefix@/sbin/uptimed -f
 Restart=on-failure
+User=daemon
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
  Debian has been running uptimed as 'daemon' for three years now.
Root permissions are unneccessary. Packagers should ensure that
/var/spool/uptimed is chown'ed on upgrade.