### PR TITLE
Use utmpx instead of utmp for Solaris

### DIFF
--- a/libuptimed/milestone.h
+++ b/libuptimed/milestone.h
@@ -32,7 +32,7 @@ uptimed - Copyright (c) 1998-2004 Rob Kaper <rob@unixcode.org>
 #ifdef xPLATFORM_SOLARIS
 #include <unistd.h>
 #include <sys/time.h>
-#include <utmp.h>
+#include <utmpx.h>
 #include <fcntl.h>
 #endif
 

--- a/libuptimed/urec.c
+++ b/libuptimed/urec.c
@@ -172,10 +172,10 @@ time_t read_uptime(void) {
 #ifdef PLATFORM_SOLARIS
 time_t read_uptime(void) {
 	int fd;
-	struct utmp ut;
+	struct utmpx ut;
 	int found=0;
 
-	fd = open (UTMP_FILE, O_RDONLY);
+	fd = open(UTMPX_FILE, O_RDONLY);
 	if (fd >= 0) {
 		while (!found) {
 			if (read(fd, &ut, sizeof(ut)) < 0) {
@@ -187,7 +187,7 @@ time_t read_uptime(void) {
 		close(fd);
 	}
 
-	if (found == 1) return time(0) - ut.ut_time;
+	if (found == 1) return time(0) - ut.ut_tv.tv_sec;
 
 	return 0;
 }
@@ -332,11 +332,11 @@ int createbootid(void) {
 int createbootid(void) {
 	FILE *f;
 	int fd;
-	struct utmp ut;
+	struct utmpx ut;
 	int found = 0;
 	time_t bootid = 0;
 
-	fd = open (UTMP_FILE, O_RDONLY);
+	fd = open (UTMPX_FILE, O_RDONLY);
 	if (fd >= 0) {
 		while(!found) {
 			if (read(fd, &ut, sizeof(ut)) < 0) {
@@ -348,7 +348,7 @@ int createbootid(void) {
 		close(fd);
 	}
 
-	if (found == 1) bootid = ut.ut_time;
+	if (found == 1) bootid = ut.ut_tv.tv_sec;
 
 	f = fopen(FILE_BOOTID, "w");
 	if (!f) {

--- a/libuptimed/urec.h
+++ b/libuptimed/urec.h
@@ -36,7 +36,7 @@ uptimed - Copyright (c) 1998-2004 Rob Kaper <rob@unixcode.org>
 #ifdef PLATFORM_SOLARIS
 #include <unistd.h>
 #include <sys/time.h>
-#include <utmp.h>
+#include <utmpx.h>
 #include <fcntl.h>
 #endif
 


### PR DESCRIPTION
The old utmp accounting files are no longer available on Solaris; POSIX standard version utmpx should be used instead.
I have a Solaris 8 OS that released on 2001 is already deprecated utmp.