### PR TITLE
Add service manifest files for Solaris SMF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 *.a
 *.la
 *.so
-*.in
 *.sub
 *.pc
 *.orig
@@ -19,10 +18,12 @@
 .deps
 .libs
 Makefile
+Makefile.in
 aclocal.m4
 autom4te.cache
 compile
 config.h
+config.h.in
 config.guess
 config.status
 confdefs.h
@@ -67,4 +68,6 @@ TAGS
 src/uptimed
 src/uprecords
 etc/uptimed.service
+etc/uptimed.xml
+etc/uptimed-bootid.xml
 uptimed.spec

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,14 @@ case "$host" in
     ;;
   *-solaris*)
     AC_DEFINE(PLATFORM_SOLARIS, 1, [Define if you are compiling for Solaris])
+    AC_ARG_WITH([smfsitemanifestdir],
+        AS_HELP_STRING([--with-smfsitemanifestdir=DIR], [Directory for SMF site manifest files [default=/var/svc/manifest/site]]),
+        [], [with_smfsitemanifestdir=/var/svc/manifest/site])
+        if test "x$with_smfsitemanifestdir" != xno; then
+            AC_SUBST([smfsitemanifestdir], [$with_smfsitemanifestdir])
+            AC_OUTPUT([etc/uptimed.xml])
+            AC_OUTPUT([etc/uptimed-bootid.xml])
+        fi
     ;;
   *-freebsd*)
     AC_DEFINE(PLATFORM_BSD, 1, [Define if you are compiling for *BSD])
@@ -54,6 +62,7 @@ case "$host" in
 esac
 
 AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir" -a "x$with_systemdsystemunitdir" != xno ])
+AM_CONDITIONAL(HAVE_SMF, [test -n "$with_smfsitemanifestdir" -a "x$with_smfsitemanifestdir" != xno ])
 
 AC_REPLACE_FUNCS(getopt)
 AC_CHECK_HEADERS(getopt.h)

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -5,3 +5,6 @@ EXTRA_DIST = uptimed.conf-dist rc.uptimed
 if HAVE_SYSTEMD
 systemdsystemunit_DATA = uptimed.service
 endif
+if HAVE_SMF
+smfsitemanifest_DATA = uptimed.xml uptimed-bootid.xml
+endif

--- a/etc/uptimed-bootid.xml.in
+++ b/etc/uptimed-bootid.xml.in
@@ -19,13 +19,12 @@
 		<service_fmri value="svc:/system/filesystem/local" />
 	</dependency>
 
-        <dependency
-                name="milestone"
-                grouping="require_all"
-                restart_on="none"
-                type="service">
-                <service_fmri value="svc:/milestone/single-user" />
-        </dependency>
+	<dependency name="milestone"
+		grouping="require_all"
+		restart_on="none"
+		type="service">
+		<service_fmri value="svc:/milestone/single-user" />
+	</dependency>
 
 	<exec_method
 		type="method"

--- a/etc/uptimed-bootid.xml.in
+++ b/etc/uptimed-bootid.xml.in
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+
+<service_bundle type="manifest" name="uptimed-bootid">
+
+<service
+	name="site/uptimed-bootid"
+	type="service"
+	version="1">
+
+	<create_default_instance enabled="false" />
+
+	<single_instance />
+
+	<dependency name="fs-local"
+		grouping="require_all"
+		restart_on="none"
+		type="service">
+		<service_fmri value="svc:/system/filesystem/local" />
+	</dependency>
+
+        <dependency
+                name="milestone"
+                grouping="require_all"
+                restart_on="none"
+                type="service">
+                <service_fmri value="svc:/milestone/single-user" />
+        </dependency>
+
+	<exec_method
+		type="method"
+		name="start"
+		exec="@prefix@/sbin/uptimed -b"
+		timeout_seconds="-1" />
+
+	<exec_method
+		type="method"
+		name="stop"
+		exec=":true"
+		timeout_seconds="-1" />
+
+	<property_group name="startd" type="framework">
+		<propval name="duration" type="astring" value="transient" />
+	</property_group>
+
+	<stability value="Unstable" />
+
+	<template>
+		<common_name>
+			<loctext xml:lang="C">
+				Create boot ID for uptimed(8) on system boots up
+			</loctext>
+		</common_name>
+		<documentation>
+			<manpage title="uptimed" section="8" manpath="@prefix@/share/man" />
+		</documentation>
+	</template>
+
+</service>
+
+</service_bundle>

--- a/etc/uptimed.xml.in
+++ b/etc/uptimed.xml.in
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+
+<service_bundle type="manifest" name="uptimed">
+
+<service
+	name="site/uptimed"
+	type="service"
+	version="1">
+
+	<create_default_instance enabled="false" />
+
+	<single_instance />
+
+	<dependency name="fs-local"
+		grouping="require_all"
+		restart_on="none"
+		type="service">
+		<service_fmri value="svc:/system/filesystem/local" />
+	</dependency>
+
+	<dependency name="uptimed-bootid"
+		grouping="optional_all"
+		restart_on="none"
+		type="service">
+		<service_fmri value="svc:/site/uptimed-bootid" />
+	</dependency>
+
+	<exec_method
+		type="method"
+		name="start"
+		exec="@prefix@/sbin/uptimed"
+		timeout_seconds="60"/>
+
+	<exec_method
+		type="method"
+		name="stop"
+		exec=":kill"
+		timeout_seconds="60" />
+
+	<property_group name="startd" type="framework">
+		<propval name="duration" type="astring" value="contract" />
+		<propval name="ignore_error" type="astring" value="core,signal" />
+	</property_group>
+
+	<stability value="Unstable" />
+
+	<template>
+		<common_name>
+			<loctext xml:lang="C">
+				Uptime record tracking daemon
+			</loctext>
+		</common_name>
+		<documentation>
+			<manpage title="uptimed" section="8" manpath="@prefix@/share/man" />
+			<manpage title="uprecord" section="1" manpath="@prefix@/share/man" />
+		</documentation>
+	</template>
+
+</service>
+
+</service_bundle>


### PR DESCRIPTION
The manifest files has been tested on a Solaris 11 OS.