### PR TITLE
Port to Android

### DIFF
--- a/libuptimed/urec.c
+++ b/libuptimed/urec.c
@@ -20,6 +20,9 @@ uptimed - Copyright (c) 1998-2004 Rob Kaper <rob@unixcode.org>
 #include "../config.h"
 #include "urec.h"
 
+#ifdef __ANDROID__
+Urec *u_current;
+#endif
 Urec *urec_list = NULL;
 static Urec *urec_last = NULL;
 

--- a/libuptimed/urec.h
+++ b/libuptimed/urec.h
@@ -54,8 +54,13 @@ extern void snprintf(char *, ...);
 
 #include "misc.h"
 
+#ifdef __ANDROID__
+#define FILE_BOOTID "/data/uptimed/bootid"
+#define FILE_RECORDS "/data/uptimed/records"
+#else
 #define FILE_BOOTID "/var/spool/uptimed/bootid"
 #define FILE_RECORDS "/var/spool/uptimed/records"
+#endif
 
 typedef struct urec {
 	time_t utime; /* uptime */

--- a/src/uprecords.c
+++ b/src/uprecords.c
@@ -25,7 +25,11 @@ uptimed - Copyright (c) 1998-2004 Rob Kaper <rob@unixcode.org>
 #define SYSWIDTH 24
 #define DOWNWIDTH 20
 
+#ifdef __ANDROID__
+extern Urec *u_current;
+#else
 Urec	*u_current;
+#endif
 time_t	first, prev, tenth, second;
 int		runas_cgi=0, show_max=10, show_milestone=0, layout=PRE, show_downtime=0, run_loop=0, update_interval=5;
 int		sort_by=0, no_ansi=0, no_stats=0, no_current=0, wide_out=0;
@@ -490,6 +494,9 @@ void scan_args(int argc, char *argv[])
 		switch(i)
 		{
 				case '?':
+#ifdef __ANDROID__
+						fputc('\n', stderr);
+#endif
 						print_help(argv);
 						break;
 				case 'a':

--- a/src/uptimed.c
+++ b/src/uptimed.c
@@ -29,7 +29,11 @@ uptimed - Copyright (c) 1998-2004 Rob Kaper <rob@unixcode.org>
 #include <getopt.h>
 #endif
 
+#ifdef __ANDROID__
+extern Urec *u_current;
+#else
 Urec *u_current = NULL;
+#endif
 int our_pos=0;
 int update_interval=60, create_bootid=0, send_email=0, foreground=0;
 time_t log_min_uptime = 0, mail_min_uptime = 0;
@@ -342,6 +346,9 @@ void scan_args(int argc, char *argv[])
 		switch(index)
 		{
 			case '?':
+#ifdef __ANDROID__
+				fputc('\n', stderr);
+#endif
 				print_help(argv);
 				break;
 			case 'v':


### PR DESCRIPTION
This pull-request fix followings:

* Move variable `u_current` from `uprecords` and `uptimed` to `libuptimed` for Android, because Bionic C library linker doesn't support referencing executable symbols from shared library, resulting following error:
```
~ # uprecords 
link_image[1891]:  5051 could not load needed library 'libuptimed.so.0' for 'uprecords' (reloc_library[1306]:  5051 cannot locate 'u_current'...
)CANNOT LINK EXECUTABLE
```
* Persistent files are stored in `/data/uptimed/`, since no `/var/` directory exists on Android.
* A small workaround for Android `getopt(3)`.