### PR TITLE
Fix non-POSIX use of echo -n

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -17,7 +17,7 @@ echo autoheader...
 
 autoheader || exit 1
 
-echo -n "libtoolize... "
+printf "%s" "libtoolize... "
 if ( (glibtoolize --version) < /dev/null > /dev/null 2>&1 ); then
 	echo "using glibtoolize"
 	glibtoolize --automake --copy --force || exit 1


### PR DESCRIPTION
Use `printf` instead of `echo -n` because `echo -n` is not portable and doesn't have the desired effect of suppressing the trailing newline (printing instead a literal "-n") on some systems such as macOS.