### PR TITLE
Change AM_CONFIG_HEADER to AC_CONFIG_HEADERS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl configure.in for uptimed
 
 AC_INIT([uptimed], 0.4.3)
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC
 AM_PROG_LIBTOOL
 AM_INIT_AUTOMAKE


### PR DESCRIPTION
Change `AM_CONFIG_HEADER` to `AC_CONFIG_HEADERS` to fix warning:

```
configure.ac:4: warning: 'AM_CONFIG_HEADER': this macro is obsolete.
configure.ac:4: You should use the 'AC_CONFIG_HEADERS' macro instead.
```