### PR TITLE
Port to AIX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,9 @@ case "$host" in
   *-solaris*)
     AC_DEFINE(PLATFORM_SOLARIS, 1, [Define if you are compiling for Solaris])
     ;;
+  *-ibm-aix*)
+    AC_DEFINE(PLATFORM_AIX, 1, [Define if you are compiling for AIX])
+    ;;
   *-freebsd*)
     AC_DEFINE(PLATFORM_BSD, 1, [Define if you are compiling for *BSD])
     ;;

--- a/libuptimed/urec.h
+++ b/libuptimed/urec.h
@@ -48,6 +48,13 @@ extern void snprintf(char *, ...);
 #include <sys/pstat.h>
 #endif
 
+#ifdef PLATFORM_AIX
+#include <sys/procfs.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#endif
+
 #ifdef PLATFORM_UNKNOWN
 #include <time.h>
 #endif

--- a/src/uprecords.c
+++ b/src/uprecords.c
@@ -25,7 +25,7 @@ uptimed - Copyright (c) 1998-2004 Rob Kaper <rob@unixcode.org>
 #define SYSWIDTH 24
 #define DOWNWIDTH 20
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) || defined(PLATFORM_AIX)
 extern Urec *u_current;
 #else
 Urec	*u_current;

--- a/src/uptimed.c
+++ b/src/uptimed.c
@@ -29,7 +29,7 @@ uptimed - Copyright (c) 1998-2004 Rob Kaper <rob@unixcode.org>
 #include <getopt.h>
 #endif
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) || defined(PLATFORM_AIX)
 extern Urec *u_current;
 #else
 Urec *u_current = NULL;


### PR DESCRIPTION
This port adds/fixes the followings:

* Similar to Android, AIX doesn't support referencing executable symbols from shared libraries; for example, after inserting a `fprintf(stderr, "&u_current = %p\n", &u_current);` statement in function `read_uptime`, running **uprecords(1)** results:
```
$ LD_LIBRARY_PATH=libuptimed/.libs/ gdb src/.libs/uprecords
GNU gdb (GDB) 7.9.1
Copyright (C) 2015 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
...
This GDB was configured as "powerpc64-ibm-aix6.1.2.0".
...
Reading symbols from src/.libs/uprecords...done.
(gdb) r
Starting program: /home/WHR/src/uptimed/build.gcc/src/.libs/uprecords 

&u_current = ffffffff
Program received signal SIGSEGV, Segmentation fault.
0xd172df74 in read_uptime () from libuptimed/.libs/libuptimed.a(libuptimed.so.0)
(gdb) bt
#0  0xd172df74 in read_uptime () from libuptimed/.libs/libuptimed.a(libuptimed.so.0)
#1  0x10000430 in main (argc=1, argv=0x2ff22cb8) at ../../src/uprecords.c:71
warning: (Internal error: pc 0x100001bb in read in psymtab, but not in symtab.)

warning: (Internal error: pc 0x100001bc in read in psymtab, but not in symtab.)
```
As it shown, the symbol `u_current` didn't get resolved correctly in `libuptimed.so.0`; therefore symbols like this have to be moved to the shared library itself.

* Add support of reading precise boot time on AIX, by reading the start time of process 0 (the swapper kernel process).