### PR TITLE
Failed to build for Linux 2.6.38 or earlier

### DIFF
--- a/libuptimed/urec.c
+++ b/libuptimed/urec.c
@@ -136,10 +136,10 @@ time_t read_uptime(void) {
 	double upseconds = 0;
 	struct sysinfo	si;
 
-
+#ifdef CLOCK_BOOTTIME
 	if (clock_gettime(CLOCK_BOOTTIME, &ts) == 0)
 		return ts.tv_sec;
-
+#endif
 
 	/* clock_gettime() failed */
 	f=fopen("/proc/uptime", "r");


### PR DESCRIPTION
When trying to build uptimed for Debian 6, I encountered this error:
```
urec.c: In function 'read_uptime':
urec.c:140: error: 'CLOCK_BOOTTIME' undeclared (first use in this function)
urec.c:140: error: (Each undeclared identifier is reported only once
urec.c:140: error: for each function it appears in.)
```

According to man page **clock_gettime(2)**, from a more recent version of Debian GNU/Linux, `CLOCK_BOOTTIME` was added since Linux 2.6.39; while the Linux UAPI provided by Debian 6 is 2.6.32.

Considering Linux 2.6.32 isn't that ancient, I would like to see uptimed to support it out-of-box.

Btw, the target platform for this build is a 50 MHz i486-based computer; the hardware information is available at <https://linux-hardware.org/?probe=3764b249f4> in case anyone interested.
