### PR TITLE
Fix erroneous error message from configure when pkg-config(1) is not available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,9 @@ case "$host" in
     PKG_PROG_PKG_CONFIG
     AC_ARG_WITH([systemdsystemunitdir],
         AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
-        [], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+        [],
+        [with_systemdsystemunitdir=$(test -n "$PKG_CONFIG" && $PKG_CONFIG --variable=systemdsystemunitdir systemd || echo no)]
+    )
         if test "x$with_systemdsystemunitdir" != xno; then
             AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
             AC_OUTPUT([etc/uptimed.service])


### PR DESCRIPTION
When configuring **uptimed** on a system without **pkg-config(1)**, the configure script prints an erroneous command not found error message:
```
checking for pkg-config... no
./configure: line 12099: --variable=systemdsystemunitdir: command not found
```

That's because when **pkg-config(1)** is not available, `PKG_CONFIG` in the script is an empty string, then the shell just runs the next command argment as command name, which is of course not desirable.
